### PR TITLE
Replace react-native-keychain w/ react-native-sensitive-info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10066,11 +10066,6 @@
         "prop-types": "15.6.1"
       }
     },
-    "react-native-keychain": {
-      "version": "3.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-3.0.0-rc.3.tgz",
-      "integrity": "sha512-ijWfHmxTPKnrHtPJiDbKW3D6lRH8O9wbCNEE3xlxEg1WZT+VhP6iiF+HUansNYuxL7Hh7k41GSFfvr3xumfmXA=="
-    },
     "react-native-maps": {
       "version": "https://github.com/expo/react-native-maps/archive/0.20.1-exp.0.tar.gz",
       "integrity": "sha512-4wlqIDq/ZZCsRk+hwfVMKjmNk1YflhmVD9oZtnJli+WEZCKPyNySWoisWgGtkSpETkmugnmSA3FExZkNhdlP+A==",
@@ -10163,6 +10158,11 @@
         "rimraf": "2.6.2",
         "xdl": "48.1.4"
       }
+    },
+    "react-native-sensitive-info": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-sensitive-info/-/react-native-sensitive-info-5.1.0.tgz",
+      "integrity": "sha1-FlXEgvmcgAI6I7LZrasa4mCxmIo="
     },
     "react-native-svg": {
       "version": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,16 @@
     "expo": "^26.0.0",
     "react": "16.3.0-alpha.1",
     "react-native": "0.54.0",
-    "react-native-keychain": "^3.0.0-rc.3",
+    "react-native-sensitive-info": "^5.1.0",
     "react-navigation": "^1.5.11",
     "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0"
   },
   "lint-staged": {
-    "*.{js}": ["prettier --write", "git add"]
+    "*.{js}": [
+      "prettier --write",
+      "git add"
+    ]
   }
 }

--- a/src/Wallet/wallet.js
+++ b/src/Wallet/wallet.js
@@ -1,5 +1,5 @@
 // Vendor
-import { setGenericPassword, getGenericPassword } from "react-native-keychain";
+import SInfo from 'react-native-sensitive-info';
 import { Wallet, providers } from "ethers";
 
 // TODO: make async
@@ -10,17 +10,17 @@ const createWallet = async () => {
 
   console.log("WALLET:", wallet);
   console.log("starting await");
-  // await setGenericPassword(address, privateKey);
-  console.log("finished set password");
+  const password = await SInfo.setItem(address, privateKey);
+  console.log("finished set password", 🙀, password, 🙀 );
   window.wallet = wallet;
   return wallet;
 };
 
-const getPassword = async () => {
+const getPassword = async (address) => {
   try {
     console.log("in try");
     // Retreive the credentials
-    const credentials = await getGenericPassword();
+    const credentials = await SInfo.getItem(address);
     if (credentials) {
       console.log(
         "Credentials successfully loaded for address " + credentials.username


### PR DESCRIPTION
### Overview
Just a straight swap of the lib we're using to store and retrieve users' keys on their android/ios device.

Couple of articles I read that inspired this:
http://randycoulman.com/blog/2017/07/25/secure-storage-in-react-native/
https://github.com/mCodex/react-native-sensitive-info/tree/keystore

This comment is worth noticing though:
http://randycoulman.com/blog/2017/07/25/secure-storage-in-react-native/#comment-3587717439